### PR TITLE
Added rule to enforce accepted mime types

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -11,8 +11,23 @@ rules:
   path-params: true
   typed-enum: true
   oas3-schema: true
+
+  must-accept-content-types:
+    description: "All enpoint bodies MUST accept the header with (one of) Content-Type: application/json, multipart/form-data, application/octet-stream"
+    message: "{{description}}"
+    severity: warn
+    given: $.paths[*].*.requestBody.content
+    then:
+      field: "@key"
+      function: enumeration
+      functionOptions:
+        values:
+          -  application/json
+          -  multipart/form-data
+          -  application/octet-stream
+
   unexpected-error-default-response:
-    description: "Endpoints must return a default response"
+    description: "All endpoints must return a default response"
     message: "{{description}}"
     severity: warn
     given: $.paths..responses


### PR DESCRIPTION
## Changes
* Updated spectral rule to check if `requestbody` of the api accepts one of the following MIME types
  * application/json 
  * multipart/form-data
  * application/octet-stream

Here is what a successful spec looks like

> ![image](https://github.com/gsoft-inc/wl-api-guidelines/assets/12961241/8faec603-75d1-468c-a561-7c4b661eb758)

He is what an unsuccessful spec looks like

> ![image](https://github.com/gsoft-inc/wl-api-guidelines/assets/12961241/d8ff19a4-3caf-4738-95c6-07e4dee289ff)

This is how Spectral shows the error

> ![image](https://github.com/gsoft-inc/wl-api-guidelines/assets/12961241/1ec8c1c0-c44d-4f67-be2b-ebde76c70163)


