### PR TITLE
Added rule to enforce returned mime types

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -26,6 +26,20 @@ rules:
           -  multipart/form-data
           -  application/octet-stream
 
+  must-return-content-types:
+    description: "All enpoint bodies MUST return the header with (one of) Content-Type: application/json, image/png, application/octet-stream"
+    message: "{{description}}"
+    severity: warn
+    given: $.paths[*].*.responses.*.content
+    then:
+      field: "@key"
+      function: enumeration
+      functionOptions:
+        values:
+          -  application/json
+          -  image/png
+          -  application/octet-stream          
+
   unexpected-error-default-response:
     description: "All endpoints must return a default response"
     message: "{{description}}"


### PR DESCRIPTION
## Changes
- Updated spectral rule to check if `responses` of the api returns one of the following MIME types
  - application/json
  - image/png
  - application/octet-stream

Here is what a successful spec looks like
> ![image](https://github.com/gsoft-inc/wl-api-guidelines/assets/12961241/91449758-f586-4a05-a012-98efa794c49d)

Here is what an unsuccessful spec looks like
> ![image](https://github.com/gsoft-inc/wl-api-guidelines/assets/12961241/b8a58373-503d-4098-8da6-6abf252490d1)

This is how Spectral shows the error
> ![image](https://github.com/gsoft-inc/wl-api-guidelines/assets/12961241/8eb81f95-098d-400b-8d79-0cd72f568193)

