### PR TITLE
[IDP-889] Add rule to enforce alphanumeric characters only in schema Ids

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -13,7 +13,7 @@ rules:
   oas3-schema: true
 
   must-accept-content-types:
-    description: "All enpoint bodies MUST accept the header with (one of) Content-Type: application/json, multipart/form-data, application/octet-stream"
+    description: "All enpoint bodies MUST accept the header with (one of) Content-Type: application/json, multipart/form-data, application/octet-stream."
     message: "{{description}}"
     severity: warn
     given: $.paths[*].*.requestBody.content
@@ -27,7 +27,7 @@ rules:
           -  application/octet-stream
 
   must-return-content-types:
-    description: "All enpoint bodies MUST return the header with (one of) Content-Type: application/json, image/png, application/octet-stream"
+    description: "All enpoint bodies MUST return the header with (one of) Content-Type: application/json, image/png, application/octet-stream."
     message: "{{description}}"
     severity: warn
     given: $.paths[*].*.responses.*.content
@@ -41,7 +41,7 @@ rules:
           -  application/octet-stream          
 
   unexpected-error-default-response:
-    description: "All endpoints must return a default response"
+    description: "All endpoints must return a default response."
     message: "{{description}}"
     severity: warn
     given: $.paths..responses

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -50,7 +50,7 @@ rules:
         function: truthy
   
   schema-ids-must-have-alphanumeric-characters-only:
-    description: 'Enforce only alphanumeric characters in schema ids.'
+    description: 'All schema ids must only contain alphanumeric characters.'
     given: "$.components.schemas"
     severity: error
     then:

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -48,3 +48,13 @@ rules:
     then:
       - field: "default"
         function: truthy
+  
+  schema-ids-must-have-alphanumeric-characters-only:
+    description: 'Enforce only alphanumeric characters in schema ids.'
+    given: "$.components.schemas"
+    severity: error
+    then:
+      field: "@key"
+      function: pattern
+      functionOptions:
+        match: '^[a-zA-Z0-9]+$'


### PR DESCRIPTION
## Description of changes
We need to prevent non-alphanumeric characters in the schema ids of generated OpenAPI spec files. We added a new rule which attempts to match the schema id with a alphanumeric regex and raises an error if the condition is not met.

## Breaking changes
This is a linting change so users may need to update their Swagger configurations.

## Additional checks
Use a sample project to validate the new spectral rule and ensured that errors are being thrown at build time. 
<img width="300" alt="image" src="https://github.com/gsoft-inc/wl-api-guidelines/assets/158102624/5804718d-9b5e-4dce-bc90-1197ec8c4320">
