### PR TITLE
[IDP-988] Added rules for type verification on items and responses

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -108,7 +108,7 @@ rules:
       function: truthy
 
   application-json-response-must-not-be-type-string:
-    description: "Responses of type application/json must not be of type string"
+    description: "Responses of type application/json must not be of type string. Having a type:string as a response causes the client generation to fail."
     recommended: true
     severity: warn
     given: $..responses..content..application/json.schema.*

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -108,7 +108,7 @@ rules:
       function: truthy
 
   application-json-response-must-not-be-type-string:
-    description: "All items must have a type."
+    description: "Responses of type application/json must not be of type string"
     recommended: true
     severity: warn
     given: $..responses..content..application/json.schema.*

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -97,3 +97,23 @@ rules:
     then:
       field: type
       function: truthy
+
+  items-must-have-a-type:
+    description: "All items must have a type."
+    recommended: true
+    severity: warn
+    given: $.components.schemas..items
+    then:
+      field: type
+      function: truthy
+
+  application-json-response-must-not-be-type-string:
+    description: "All items must have a type."
+    recommended: true
+    severity: warn
+    given: $..responses..content..application/json.schema.*
+    then:
+      field: type
+      function: pattern
+      functionOptions:
+        notMatch: 'string'

--- a/TestSpecs/application-json-response-must-not-be-type-string-invalid.yaml
+++ b/TestSpecs/application-json-response-must-not-be-type-string-invalid.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.1
+info:
+  title: V1 API General
+  version: v1
+paths:
+  /buy-item:
+    post:
+      tags:
+        - Shop
+      summary: Buy an item
+      operationId: BuyItem
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                required:
+                  - itemName
+                type: string

--- a/TestSpecs/application-json-response-must-not-be-type-string-valid.yaml
+++ b/TestSpecs/application-json-response-must-not-be-type-string-valid.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.1
+info:
+  title: V1 API General
+  version: v1
+paths:
+  /buy-item:
+    post:
+      tags:
+        - Shop
+      summary: Buy an item
+      operationId: BuyItem
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                required:
+                  - itemName
+                type: object

--- a/TestSpecs/items-must-have-a-type-invalid.yaml
+++ b/TestSpecs/items-must-have-a-type-invalid.yaml
@@ -1,0 +1,8 @@
+openapi: 3.0.1
+info:
+  title: dummy
+components:
+  schemas:
+    SampleObject:
+      type: array
+      items:

--- a/TestSpecs/items-must-have-a-type-valid.yaml
+++ b/TestSpecs/items-must-have-a-type-valid.yaml
@@ -1,0 +1,9 @@
+openapi: 3.0.1
+info:
+  title: dummy
+components:
+  schemas:
+    SampleObject:
+      type: array
+      items:
+        type: string

--- a/test.ps1
+++ b/test.ps1
@@ -8,6 +8,10 @@ spectral --version
 $ruleset = Join-Path $PSScriptRoot ".spectral.yaml"
 
 $tests = @(
+    @{ rule = "application-json-response-must-not-be-type-string"; expectError = $false; filename = "application-json-response-must-not-be-type-string-valid.yaml" },
+    @{ rule = "application-json-response-must-not-be-type-string"; expectError = $true; filename = "application-json-response-must-not-be-type-string-invalid.yaml" },
+    @{ rule = "items-must-have-a-type"; expectError = $false; filename = "items-must-have-a-type-valid.yaml" },
+    @{ rule = "items-must-have-a-type"; expectError = $true; filename = "items-must-have-a-type-invalid.yaml" },
     @{ rule = "must-accept-content-types"; expectError = $false; filename = "must-accept-content-types-valid.yaml" },
     @{ rule = "must-accept-content-types"; expectError = $true; filename = "must-accept-content-types-invalid.yaml" },
     @{ rule = "must-have-security-schemes"; expectError = $false; filename = "must-have-security-schemes-valid.yaml" },


### PR DESCRIPTION
## Description of changes
Added two spectral rules:
- Verify that the items field of a `type: array` collection has a type field defined in the spec.
- Verify that application/json responses are not of type string

## Breaking changes
This may break existing OpenAPI specs.

## Additional checks
Validate that CI passes with the new rules.

- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
