### PR TITLE
[IDP-1193] Added rules to support client generation

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -5,6 +5,8 @@ rules:
   no-eval-in-markdown: true
   no-script-tags-in-markdown: true
   openapi-tags-uniqueness: true
+  operation-operationId: true
+  operation-operationId-valid-in-url: true
   operation-operationId-unique: true
   operation-success-response: true
   path-keys-no-trailing-slash: true


### PR DESCRIPTION
## Description of changes
Added `operationId` rule to support client generation
This enforces the use of `operationId`.

## Breaking changes
OpenAPI contract without operationId defined will fail the validation

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
