### PR TITLE
[IDP-1402] Enforce application/json return only on 200 responses

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -30,10 +30,10 @@ rules:
           -  application/octet-stream
 
   must-return-content-types:
-    description: "All endpoint bodies MUST return the header with (one of) Content-Type: application/json, image/png, application/octet-stream."
+    description: "Endpoint bodies for 200 responses MUST return the header with (one of) Content-Type: application/json, image/png, application/octet-stream."
     message: "{{description}}"
     severity: warn
-    given: $.paths[*].*.responses.*.content
+    given: $.paths[*].*.responses['200'].content
     then:
       field: "@key"
       function: enumeration

--- a/TestSpecs/must-return-content-types-valid.yaml
+++ b/TestSpecs/must-return-content-types-valid.yaml
@@ -24,3 +24,9 @@ paths:
                     minLength: 1
                     type: string
                 additionalProperties: false
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string


### PR DESCRIPTION
## Description of changes
Enforce application/json return type rule only on 200 responses instead of all responses.

## Breaking changes
None

- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
