### PR TITLE
IDP-2085 - Add cortex descriptor file

### DIFF
--- a/.cortex/catalog/service-wl-api-guidelines.yaml
+++ b/.cortex/catalog/service-wl-api-guidelines.yaml
@@ -1,0 +1,24 @@
+# https://docs.cortex.io/docs/reference/basics/entities#service-entities
+
+openapi: 3.0.1
+info:
+  title: Workleap Api Guildelines
+  x-cortex-git:
+    github:
+      alias: gsoft-inc
+      repository: gsoft-inc/wl-api-guidelines
+  x-cortex-tag: service-wl-api-guidelines
+  x-cortex-type: service
+  x-cortex-slack:
+    channels:
+    - name: internal-dev-platform
+      notificationsEnabled: true
+  x-cortex-owners:
+  - name: team-internal-developer-platform-backend
+    type: GROUP
+    provider: CORTEX
+  x-cortex-link:
+  - type: cortex
+    url: https://github.com/gsoft-inc/cortex-gitops/blob/main/.cortex/catalog/service-wl-api-guidelines.yaml
+    name: Edit current Cortex entity in GitHub
+


### PR DESCRIPTION
This PR adds the cortex descriptor file for this service. This is the file that Cortex will use to populate your service into the catalog.