### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         shell: pwsh
         
   linearb:
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: release
     secrets: inherit

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow-jira:
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
     with:
       branch_name: ${{ github.head_ref }}
     secrets: inherit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,4 +12,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main

--- a/.spectral.backend.yaml
+++ b/.spectral.backend.yaml
@@ -1,4 +1,4 @@
-extends: [[https://raw.githubusercontent.com/gsoft-inc/wl-api-guidelines/main/.workleap.rules.yaml, off]]
+extends: [[https://raw.githubusercontent.com/workleap/wl-api-guidelines/main/.workleap.rules.yaml, off]]
 documentationUrl: https://gsoftdev.atlassian.net/wiki/spaces/TEC/pages/3858235678/IDP+OpenAPI+Rulesets
 rules:
   duplicated-entry-in-enum: true

--- a/.spectral.frontend.yaml
+++ b/.spectral.frontend.yaml
@@ -1,4 +1,4 @@
-extends: [[https://raw.githubusercontent.com/gsoft-inc/wl-api-guidelines/main/.workleap.rules.yaml, off]]
+extends: [[https://raw.githubusercontent.com/workleap/wl-api-guidelines/main/.workleap.rules.yaml, off]]
 documentationUrl: https://gsoftdev.atlassian.net/wiki/spaces/TEC/pages/3858235678/IDP+OpenAPI+Rulesets
 rules:
   duplicated-entry-in-enum: true


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 